### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# SpofityManager
+
+## Environment configuration
+
+This project expects aligned client and server environment settings so the React frontend and Express backend agree on shared URLs. Copy the provided templates and adjust them for your deployment targets:
+
+- Copy `client/.env.local.example` to `client/.env.local`.
+- Copy `server/.env.example` to `server/.env`.
+
+| Variable | Where it is used | Description |
+| --- | --- | --- |
+| `REACT_APP_API_BASE_URL` / `API_BASE_URL` | Client & server | Base URL for the API server (Express backend). |
+| `REACT_APP_CLIENT_BASE_URL` / `CLIENT_BASE_URL` | Client & server | Public URL of the React client. The server also derives its CORS whitelist from this value. |
+| `REACT_APP_SPOTIFY_REDIRECT_URI` / `SPOTIFY_REDIRECT_URI` | Client & server | Spotify callback URL used after authentication. |
+| `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET` | Server only | Credentials from the Spotify dashboard. |
+
+> **Tip:** You can supply multiple client URLs to `CLIENT_BASE_URL` by separating them with commas (e.g. `https://app.example.com,https://staging.example.com`). The first entry is treated as the default redirect location.
+
+## Spotify dashboard setup
+
+Update your Spotify application settings so both your production callback URL and the local development callback URL are present under **Redirect URIs**. This should include:
+
+- Your production redirect, e.g. `https://your-domain.com/api/callback`.
+- The local development redirect `http://localhost:5001/callback` (or whatever you choose for local testing).
+
+Remember to keep these values synchronized with `SPOTIFY_REDIRECT_URI` across the client and server configuration files.

--- a/client/.env.local.example
+++ b/client/.env.local.example
@@ -1,0 +1,5 @@
+# Client environment variables
+REACT_APP_API_BASE_URL=http://localhost:5001
+# Should mirror the primary entry in the server CLIENT_BASE_URL value
+REACT_APP_CLIENT_BASE_URL=http://localhost:3000
+REACT_APP_SPOTIFY_REDIRECT_URI=http://localhost:5001/callback

--- a/client/src/config/env.js
+++ b/client/src/config/env.js
@@ -1,0 +1,17 @@
+const trimTrailingSlash = (value) => value.replace(/\/$/, "");
+
+const apiBaseFallback = "http://localhost:5001";
+const clientBaseFallback = "http://localhost:3000";
+
+const API_BASE_URL = trimTrailingSlash(
+  process.env.REACT_APP_API_BASE_URL || apiBaseFallback
+);
+
+const CLIENT_BASE_URL = trimTrailingSlash(
+  process.env.REACT_APP_CLIENT_BASE_URL || clientBaseFallback
+);
+
+const SPOTIFY_REDIRECT_URI =
+  process.env.REACT_APP_SPOTIFY_REDIRECT_URI || `${API_BASE_URL}/callback`;
+
+export { API_BASE_URL, CLIENT_BASE_URL, SPOTIFY_REDIRECT_URI };

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { API_BASE_URL } from "../config/env";
 
 export default function LandingPage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -7,7 +8,7 @@ export default function LandingPage() {
   const handleLogin = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch("http://localhost:5001/login");
+      const response = await fetch(`${API_BASE_URL}/login`);
       const data = await response.json();
       window.location.href = data.url; // Redirect user to Spotify login
     } catch (error) {

--- a/client/src/pages/PlaylistComparison.js
+++ b/client/src/pages/PlaylistComparison.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { API_BASE_URL } from "../config/env";
 
 function ComparisonPage() {
   const location = useLocation();
@@ -24,7 +25,7 @@ function ComparisonPage() {
     for (const playlist of selectedPlaylists) {
       try {
         const response = await fetch(
-          `http://localhost:5001/playlist/${playlist.id}/tracks`,
+          `${API_BASE_URL}/playlist/${playlist.id}/tracks`,
           { credentials: "include" }
         );
         if (!response.ok) {
@@ -43,7 +44,7 @@ function ComparisonPage() {
     const url = `https://api.spotify.com/v1/playlists/${playlistId}/tracks`;
 
     try {
-      const tokenResponse = await fetch("http://localhost:5001/token", {
+      const tokenResponse = await fetch(`${API_BASE_URL}/token`, {
         credentials: "include",
       });
       const tokenData = await tokenResponse.json();
@@ -114,7 +115,7 @@ function ComparisonPage() {
     const url = `https://api.spotify.com/v1/playlists/${playlistId}/tracks?uris=${encodedUri}`;
 
     try {
-      const tokenResponse = await fetch("http://localhost:5001/token", {
+      const tokenResponse = await fetch(`${API_BASE_URL}/token`, {
         credentials: "include",
       });
       const tokenData = await tokenResponse.json();

--- a/client/src/pages/PlaylistsPage.js
+++ b/client/src/pages/PlaylistsPage.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { API_BASE_URL } from "../config/env";
 
 function PlaylistsPage() {
   const navigate = useNavigate();
@@ -15,7 +16,7 @@ function PlaylistsPage() {
 
   const fetchPlaylists = async () => {
     try {
-      const response = await fetch("http://localhost:5001/playlists", {
+      const response = await fetch(`${API_BASE_URL}/playlists`, {
         credentials: "include",
       });
       const data = await response.json();
@@ -27,7 +28,7 @@ function PlaylistsPage() {
 
   const fetchUserProfile = async () => {
     try {
-      const response = await fetch("http://localhost:5001/user", {
+      const response = await fetch(`${API_BASE_URL}/user`, {
         credentials: "include",
       });
       const data = await response.json();

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,8 @@
+# Server environment variables
+PORT=5001
+API_BASE_URL=http://localhost:5001
+# Accepts a single URL or a comma-separated list (first is used for redirects)
+CLIENT_BASE_URL=http://localhost:3000
+SPOTIFY_REDIRECT_URI=http://localhost:5001/callback
+SPOTIFY_CLIENT_ID=your-spotify-client-id
+SPOTIFY_CLIENT_SECRET=your-spotify-client-secret

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,27 @@
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const PORT = process.env.PORT || 5001;
+const API_BASE_URL = process.env.API_BASE_URL || `http://localhost:${PORT}`;
+const rawClientBaseUrl =
+  process.env.CLIENT_BASE_URL || "http://localhost:3000";
+const parsedClientBaseUrls = rawClientBaseUrl
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const CLIENT_BASE_URLS =
+  parsedClientBaseUrls.length > 0
+    ? parsedClientBaseUrls
+    : ["http://localhost:3000"];
+const CLIENT_BASE_URL = CLIENT_BASE_URLS[0];
+const SPOTIFY_REDIRECT_URI =
+  process.env.SPOTIFY_REDIRECT_URI || `${API_BASE_URL}/callback`;
+
+module.exports = {
+  PORT,
+  API_BASE_URL,
+  CLIENT_BASE_URL,
+  CLIENT_BASE_URLS,
+  SPOTIFY_REDIRECT_URI,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -2,14 +2,21 @@ const express = require("express");
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const SpotifyWebApi = require("spotify-web-api-node");
-require("dotenv").config();
+
+const {
+  PORT,
+  CLIENT_BASE_URLS,
+  CLIENT_BASE_URL,
+  SPOTIFY_REDIRECT_URI,
+} = require("./config");
 
 const app = express();
+const baseClientUrl = CLIENT_BASE_URL.replace(/\/$/, "");
 
 // Middleware
 app.use(
   cors({
-    origin: "http://localhost:3000",
+    origin: CLIENT_BASE_URLS,
     credentials: true,
   })
 );
@@ -19,7 +26,7 @@ app.use(express.json());
 const spotifyApi = new SpotifyWebApi({
   clientId: process.env.SPOTIFY_CLIENT_ID,
   clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-  redirectUri: "http://localhost:5001/callback",
+  redirectUri: SPOTIFY_REDIRECT_URI,
 });
 
 // Get stored access token
@@ -57,10 +64,10 @@ app.get("/callback", async (req, res) => {
     res.cookie("access_token", access_token, { httpOnly: true });
     res.cookie("refresh_token", refresh_token, { httpOnly: true });
 
-    res.redirect("http://localhost:3000/playlists");
+    res.redirect(`${baseClientUrl}/playlists`);
   } catch (error) {
     console.error("Error getting tokens:", error);
-    res.redirect("http://localhost:3000/error");
+    res.redirect(`${baseClientUrl}/error`);
   }
 });
 
@@ -117,7 +124,6 @@ app.post("/logout", (req, res) => {
 });
 
 // 🚀 Start Server
-const PORT = process.env.PORT || 5001;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add shared client config that reads environment variables for API and redirect URLs
- use environment-driven URLs on the server via a shared config module and update redirects
- document environment templates for both client and server and outline Spotify redirect setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fcaa1f93c8326a72f1bff1872d2e0)